### PR TITLE
Correctly build hierarchy subtrees for default theme

### DIFF
--- a/bin/default/partials/hierarchy.hbs
+++ b/bin/default/partials/hierarchy.hbs
@@ -8,7 +8,7 @@
             {{/if}}
 
             {{#if @last}}
-                {{#with ../../next}}
+                {{#with ../next}}
                     {{> hierarchy}}
                 {{/with}}
             {{/if}}

--- a/bin/default/partials/member.getterSetter.hbs
+++ b/bin/default/partials/member.getterSetter.hbs
@@ -3,6 +3,7 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -11,6 +12,7 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}

--- a/bin/default/partials/member.getterSetter.hbs
+++ b/bin/default/partials/member.getterSetter.hbs
@@ -3,7 +3,6 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -12,7 +11,6 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}

--- a/bin/minimal/partials/hierarchy.hbs
+++ b/bin/minimal/partials/hierarchy.hbs
@@ -8,7 +8,7 @@
             {{/if}}
 
             {{#if @last}}
-                {{#with ../../next}}
+                {{#with ../next}}
                     {{> hierarchy}}
                 {{/with}}
             {{/if}}

--- a/bin/minimal/partials/member.getterSetter.hbs
+++ b/bin/minimal/partials/member.getterSetter.hbs
@@ -3,6 +3,7 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -11,6 +12,7 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}

--- a/bin/minimal/partials/member.getterSetter.hbs
+++ b/bin/minimal/partials/member.getterSetter.hbs
@@ -3,7 +3,6 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -12,7 +11,6 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-default-themes",
   "description": "Default themes for TypeDoc.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "http://typedoc.io",
   "main": "bin/plugin.js",
   "author": {

--- a/src/default/partials/hierarchy.hbs
+++ b/src/default/partials/hierarchy.hbs
@@ -8,7 +8,7 @@
             {{/if}}
 
             {{#if @last}}
-                {{#with ../../next}}
+                {{#with ../next}}
                     {{> hierarchy}}
                 {{/with}}
             {{/if}}

--- a/src/default/partials/member.getterSetter.hbs
+++ b/src/default/partials/member.getterSetter.hbs
@@ -3,6 +3,7 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -11,6 +12,7 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
+                {{../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}

--- a/src/default/partials/member.getterSetter.hbs
+++ b/src/default/partials/member.getterSetter.hbs
@@ -3,7 +3,6 @@
         {{#with getSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">get</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}
@@ -12,7 +11,6 @@
         {{#with setSignature}}
             <li class="tsd-signature tsd-kind-icon">{{#compact}}
                 <span class="tsd-signature-symbol">set</span>&nbsp;
-                {{../../name}}
                 {{> member.signature.title hideName=true }}
             {{/compact}}</li>
         {{/with}}


### PR DESCRIPTION
This pull request fixes the `hierarchy.hbs` template to ensure that it correctly generates substrees (referencing the correct `next`).

This is required to make the tests for https://github.com/TypeStrong/typedoc/pull/204 pass.
