### PR TITLE
Images takes too much space

### DIFF
--- a/src/default/assets/css/elements/_images.sass
+++ b/src/default/assets/css/elements/_images.sass
@@ -1,0 +1,2 @@
+// fixes issue with images in readme
+img { max-width: 100% }

--- a/src/default/assets/css/main.sass
+++ b/src/default/assets/css/main.sass
@@ -24,3 +24,4 @@
 @import elements/signatures
 @import elements/sources
 @import elements/toolbar
+@import elements/images


### PR DESCRIPTION
During development I faced an issue with Images added in the Readme which would be too large for the container.

![Facing Issue during development](http://ts-google-map.dominikangerer.com/github-images/pr-typedocs.png)

Fixed version lookes like: http://ts-google-map.dominikangerer.com/docs/
