### PR TITLE
Text change from "overwrites" to "overrides" and version bumped to 0.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-default-themes",
   "description": "Default themes for TypeDoc.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "http://typedoc.io",
   "main": "bin/plugin.js",
   "files": [

--- a/src/default/assets/css/elements/_sources.sass
+++ b/src/default/assets/css/elements/_sources.sass
@@ -1,7 +1,7 @@
 // Displays the source and inheritance information
 //
 // <aside class="tsd-sources">
-//   <p>Overwrites <a href="#">BaseHandler</a>.<a href="#">constructor</a></p>
+//   <p>Overrides <a href="#">BaseHandler</a>.<a href="#">constructor</a></p>
 //   <ul>
 //     <li>Defined in src/typedoc/factories/handlers/DynamicModuleHandler.ts:37</li>
 //   </ul>

--- a/src/default/partials/member.sources.hbs
+++ b/src/default/partials/member.sources.hbs
@@ -6,7 +6,7 @@
         <p>Inherited from {{#with inheritedFrom}}{{> typeAndParent}}{{/with}}</p>
     {{/if}}
     {{#if overwrites}}
-        <p>Overwrites {{#with overwrites}}{{> typeAndParent}}{{/with}}</p>
+        <p>Overrides {{#with overwrites}}{{> typeAndParent}}{{/with}}</p>
     {{/if}}
     {{#if sources}}
         <ul>


### PR DESCRIPTION
…4.1. Fix for https://github.com/TypeStrong/typedoc/issues/271
