### PR TITLE
Remove include of missing modernizr.js

### DIFF
--- a/src/default/layouts/default.hbs
+++ b/src/default/layouts/default.hbs
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="{{relativeURL "assets/css/main.css"}}">
-    <script src="{{relativeURL "assets/js/modernizr.js"}}"></script>
 </head>
 <body>
 


### PR DESCRIPTION
The theme tries to load modernizr.js from the assets directory but it's not there. Works fine without it, I guess it was meant for older browsers? Well, this pull request removes the script line to get rid of the loading error.

Related: https://github.com/TypeStrong/typedoc/issues/286
