### PR TITLE
Fix broken typedoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Default themes for TypeDoc
 
 This module contains the default themes of TypeDoc.
-Visit https://typedoc.io to learn more about TypeDoc.
+Visit http://typedoc.org/ to learn more about TypeDoc.
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typedoc-default-themes",
   "description": "Default themes for TypeDoc.",
   "version": "0.4.0",
-  "homepage": "http://typedoc.io",
+  "homepage": "http://typedoc.org/",
   "main": "bin/plugin.js",
   "files": [
     "bin",

--- a/src/default/partials/footer.hbs
+++ b/src/default/partials/footer.hbs
@@ -61,6 +61,6 @@
 
 {{#unless settings.hideGenerator}}
     <div class="container tsd-generator">
-        <p>Generated using <a href="http://typedoc.io" target="_blank">TypeDoc</a></p>
+        <p>Generated using <a href="http://typedoc.org/" target="_blank">TypeDoc</a></p>
     </div>
 {{/unless}}


### PR DESCRIPTION
The footer references a page which is not available. Looks like TypeDoc moved from typedoc.io to typedoc.org. This PR changes the URL in the footer, the README and the package.json

Related: #16 
