### PR TITLE
Add check for Union array type.

### DIFF
--- a/src/default/assets/js/main.js
+++ b/src/default/assets/js/main.js
@@ -1,8 +1,13 @@
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
 var typedoc;
 (function (typedoc) {
     typedoc.$html = $('html');
@@ -119,7 +124,7 @@ var typedoc;
     var FilterItemCheckbox = (function (_super) {
         __extends(FilterItemCheckbox, _super);
         function FilterItemCheckbox() {
-            return _super.apply(this, arguments) || this;
+            return _super !== null && _super.apply(this, arguments) || this;
         }
         FilterItemCheckbox.prototype.initialize = function () {
             var _this = this;
@@ -143,7 +148,7 @@ var typedoc;
     var FilterItemSelect = (function (_super) {
         __extends(FilterItemSelect, _super);
         function FilterItemSelect() {
-            return _super.apply(this, arguments) || this;
+            return _super !== null && _super.apply(this, arguments) || this;
         }
         FilterItemSelect.prototype.initialize = function () {
             var _this = this;

--- a/src/default/partials/type.hbs
+++ b/src/default/partials/type.hbs
@@ -19,11 +19,18 @@
         {{/compact}}
     {{else}}
         {{#if types}}
+            {{#if isArray}}
+            <span class="tsd-signature-symbol">(</span>
+            {{/if}}
             {{#each types}}
                 {{#if @index}}
                     <span class="tsd-signature-symbol"> | </span>
                 {{/if}}{{> type}}
             {{/each}}
+            {{#if isArray}}
+            <span class="tsd-signature-symbol">)</span>
+            <span class="tsd-signature-symbol">[]</span>
+            {{/if}}
         {{else}}
             {{#if elements}}
                 {{#compact}}


### PR DESCRIPTION
This issue is detailed in TypeStrong/typedoc#292, and adds a `isArray` check around union types.

For some code to be documented:

```ts
export function regex(regexp: RegExp): string | number | (string | number)[] {
}
```

This fix produces the following output:

<img width="844" alt="screen shot 2017-03-09 at 4 57 15 pm" src="https://cloud.githubusercontent.com/assets/293805/23774485/76525a2e-04e9-11e7-9e7f-8ff7c7da3c25.png">
