### PR TITLE
Minimal theme patches

### DIFF
--- a/src/minimal/layouts/default.hbs
+++ b/src/minimal/layouts/default.hbs
@@ -22,10 +22,10 @@
 
 <div class="container container-main">
     <div class="content-wrap">
-    	{{#if model.readme}}
-			<div class="tsd-panel tsd-typography">
-				{{#markdown}}{{{model.readme}}}{{/markdown}}
-			</div>
+        {{#if model.readme}}
+                <div class="tsd-panel tsd-typography">
+                        {{#markdown}}{{{model.readme}}}{{/markdown}}
+                </div>
         {{/if}}
 
         {{{contents}}}

--- a/src/minimal/layouts/default.hbs
+++ b/src/minimal/layouts/default.hbs
@@ -22,9 +22,11 @@
 
 <div class="container container-main">
     <div class="content-wrap">
-        <div class="tsd-panel tsd-typography">
-            {{#markdown}}{{{model.readme}}}{{/markdown}}
-        </div>
+    	{{#if model.readme}}
+			<div class="tsd-panel tsd-typography">
+				{{#markdown}}{{{model.readme}}}{{/markdown}}
+			</div>
+        {{/if}}
 
         {{{contents}}}
         {{> footer}}

--- a/src/minimal/partials/member.hbs
+++ b/src/minimal/partials/member.hbs
@@ -1,7 +1,7 @@
 <section class="tsd-panel tsd-member {{cssClasses}}">
     <a name="{{anchor}}" class="tsd-anchor"></a>
     {{#if name}}
-        <h3>{{#each flagsArray}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
+        <h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
     {{/if}}
 
     {{#if signatures}}


### PR DESCRIPTION
 - Added guard against empty `model.readme` which prevents an empty box at the top of the page when `model.readme` is empty
- Used correct name for flags array which ensures the flags are made visible. Flags such as `static` and `optional` were not appearing