### PR TITLE
Support for intersection types

### DIFF
--- a/src/default/partials/type.hbs
+++ b/src/default/partials/type.hbs
@@ -24,7 +24,7 @@
             {{/if}}
             {{#each types}}
                 {{#if @index}}
-                    <span class="tsd-signature-symbol"> | </span>
+                    <span class="tsd-signature-symbol"> {{#ifCond ../type '==' 'intersection'}}&amp;{{else}}|{{/ifCond}} </span>
                 {{/if}}{{> type}}
             {{/each}}
             {{#if isArray}}


### PR DESCRIPTION
This PR is an addition to TypeStrong/typedoc#482 and outputs the right separator for intersection/union types.