### PR TITLE
Lumped together titles+descriptions for overloaded functions

### DIFF
--- a/src/default/partials/member.signatures.hbs
+++ b/src/default/partials/member.signatures.hbs
@@ -1,13 +1,11 @@
-<ul class="tsd-signatures {{cssClasses}}">
-    {{#each signatures}}
+{{#each signatures}}
+	<ul class="tsd-signatures {{cssClasses}}">
         <li class="tsd-signature tsd-kind-icon">{{> member.signature.title }}</li>
-    {{/each}}
-</ul>
+	</ul>
 
-<ul class="tsd-descriptions">
-    {{#each signatures}}
+	<ul class="tsd-descriptions">
         <li class="tsd-description">
             {{> member.signature.body }}
         </li>
-    {{/each}}
-</ul>
+	</ul>
+{{/each}}

--- a/src/default/partials/parameter.hbs
+++ b/src/default/partials/parameter.hbs
@@ -1,6 +1,6 @@
 <ul class="tsd-parameters">
     {{#if signatures}}
-        <li class="tsd-parameter-siganture">
+        <li class="tsd-parameter-signature">
             <ul class="tsd-signatures {{cssClasses}}">
                 {{#each signatures}}
                     <li class="tsd-signature tsd-kind-icon">{{> member.signature.title hideName=true }}</li>


### PR DESCRIPTION
Previous methodology had (for overloaded functions) all the overloaded function titles listed, and then all of the descriptions. Shown below:

![orig](https://cloud.githubusercontent.com/assets/6731455/25641025/a39fa340-2f57-11e7-9e5e-0e21a06fab05.png)

This PR now lists each title+description pair so that users know what description belongs to which overloaded function. New format shown below:

![new](https://cloud.githubusercontent.com/assets/6731455/25641049/c1579f14-2f57-11e7-802a-721007a89ef3.png)
