### PR TITLE
Show the type of destructuring parameter in case it has type defined

### DIFF
--- a/src/default/partials/type.hbs
+++ b/src/default/partials/type.hbs
@@ -1,83 +1,87 @@
-{{#if this}}
-    {{#if reflection}}
-        {{#compact}}
-            <a href="{{relativeURL reflection.url}}" class="tsd-signature-type">
-                {{reflection.name}}
-            </a>
-            {{#if typeArguments}}
-                <span class="tsd-signature-symbol">&lt;</span>
+{{#if declaration.type}}
+    {{#with declaration.type}}{{> type}}{{/with}}
+{{else}}
+    {{#if this}}
+        {{#if reflection}}
+            {{#compact}}
+                <a href="{{relativeURL reflection.url}}" class="tsd-signature-type">
+                    {{reflection.name}}
+                </a>
+                {{#if typeArguments}}
+                    <span class="tsd-signature-symbol">&lt;</span>
 
-                {{#each typeArguments}}
-                    {{#if @index}}
-                        <span class="tsd-signature-symbol">, </span>
-                    {{/if}}{{> type}}
-                {{/each}}
+                    {{#each typeArguments}}
+                        {{#if @index}}
+                            <span class="tsd-signature-symbol">, </span>
+                        {{/if}}{{> type}}
+                    {{/each}}
 
-                <span class="tsd-signature-symbol">&gt;</span>
-            {{/if}}
-        {{/compact}}
-    {{else}}
-        {{#if elementType}}
-            {{#with elementType}}
-                {{#compact}}
-                    {{#if types}}
-                        <span class="tsd-signature-symbol">(</span>
-                    {{/if}}
-                    {{> type}}
-                    {{#if types}}
-                        <span class="tsd-signature-symbol">)</span>
-                    {{/if}}<span class="tsd-signature-symbol">[]</span>
-                {{/compact}}
-            {{/with}}
+                    <span class="tsd-signature-symbol">&gt;</span>
+                {{/if}}
+            {{/compact}}
         {{else}}
-            {{#if types}}
-                {{#each types}}
-                    {{#if @index}}
-                        <span class="tsd-signature-symbol"> {{#ifCond ../type '==' 'intersection'}}&amp;{{else}}|{{/ifCond}} </span>
-                    {{/if}}{{> type}}
-                {{/each}}
-            {{else}}
-                {{#if elements}}
+            {{#if elementType}}
+                {{#with elementType}}
                     {{#compact}}
-                        <span class="tsd-signature-symbol">[</span>
-
-                        {{#each elements}}
-                            {{#if @index}}
-                                <span class="tsd-signature-symbol">, </span>
-                            {{/if}}{{> type}}
-                        {{/each}}
-
-                        <span class="tsd-signature-symbol">]</span>
+                        {{#if types}}
+                            <span class="tsd-signature-symbol">(</span>
+                        {{/if}}
+                        {{> type}}
+                        {{#if types}}
+                            <span class="tsd-signature-symbol">)</span>
+                        {{/if}}<span class="tsd-signature-symbol">[]</span>
                     {{/compact}}
+                {{/with}}
+            {{else}}
+                {{#if types}}
+                    {{#each types}}
+                        {{#if @index}}
+                            <span class="tsd-signature-symbol"> {{#ifCond ../type '==' 'intersection'}}&amp;{{else}}|{{/ifCond}} </span>
+                        {{/if}}{{> type}}
+                    {{/each}}
                 {{else}}
-                    {{#compact}}
-                        <span class="tsd-signature-type">
-                            {{#if name}}
-                                {{name}}
-                            {{else}}
-                                {{#if value}}
-                                    "{{value}}"
-                                {{else}}
-                                    {{this}}
-                                {{/if}}
-                            {{/if}}
-                        </span>
-                        {{#if typeArguments}}
-                            <span class="tsd-signature-symbol">&lt;</span>
+                    {{#if elements}}
+                        {{#compact}}
+                            <span class="tsd-signature-symbol">[</span>
 
-                            {{#each typeArguments}}
+                            {{#each elements}}
                                 {{#if @index}}
                                     <span class="tsd-signature-symbol">, </span>
                                 {{/if}}{{> type}}
                             {{/each}}
 
-                            <span class="tsd-signature-symbol">&gt;</span>
-                        {{/if}}
-                    {{/compact}}
+                            <span class="tsd-signature-symbol">]</span>
+                        {{/compact}}
+                    {{else}}
+                        {{#compact}}
+                            <span class="tsd-signature-type">
+                                {{#if name}}
+                                    {{name}}
+                                {{else}}
+                                    {{#if value}}
+                                        "{{value}}"
+                                    {{else}}
+                                        {{this}}
+                                    {{/if}}
+                                {{/if}}
+                            </span>
+                            {{#if typeArguments}}
+                                <span class="tsd-signature-symbol">&lt;</span>
+
+                                {{#each typeArguments}}
+                                    {{#if @index}}
+                                        <span class="tsd-signature-symbol">, </span>
+                                    {{/if}}{{> type}}
+                                {{/each}}
+
+                                <span class="tsd-signature-symbol">&gt;</span>
+                            {{/if}}
+                        {{/compact}}
+                    {{/if}}
                 {{/if}}
             {{/if}}
         {{/if}}
+    {{else}}
+        <span class="tsd-signature-type">void</span>
     {{/if}}
-{{else}}
-    <span class="tsd-signature-type">void</span>
 {{/if}}


### PR DESCRIPTION
This is a follow-up PR for pull request on main repo - https://github.com/TypeStrong/typedoc/pull/621. This changes the displayed type of destructured parameter:

```
/**
 * A function with a destructuring argument that implements interface.
 */
export function functionWithTypedDestr({name}: classes.INameInterface) { }
```

Before change:

![typed_desctr](https://user-images.githubusercontent.com/6412426/31520401-657b0122-afae-11e7-9eb8-3f73826144bd.png)

After change:

![typed_desctr_new](https://user-images.githubusercontent.com/6412426/31520407-6bf4d17c-afae-11e7-885f-84bbe0ce9778.png)

No other test cases are affected by this change.