### PR TITLE
Fixing tag comment display.

### DIFF
--- a/src/default/assets/css/elements/_comment.sass
+++ b/src/default/assets/css/elements/_comment.sass
@@ -28,11 +28,8 @@ dl.tsd-comment-tags
 
     dd
         margin: 0 0 10px 0
-        &:after
+        pre, &:after
             clear: both
-
-    pre
-        margin-top: 14px
 
     p
         margin: 0

--- a/src/default/assets/css/elements/_comment.sass
+++ b/src/default/assets/css/elements/_comment.sass
@@ -12,8 +12,11 @@
 dl.tsd-comment-tags
     overflow: hidden
 
+    dt:before, dd:before
+        display: table
+        content: " "
+
     dt
-        clear: both
         float: left
         padding: 1px 5px
         margin: 0 10px 0 0
@@ -25,6 +28,11 @@ dl.tsd-comment-tags
 
     dd
         margin: 0 0 10px 0
+        &:after
+            clear: both
+
+    pre
+        margin-top: 14px
 
     p
         margin: 0

--- a/src/default/assets/css/elements/_comment.sass
+++ b/src/default/assets/css/elements/_comment.sass
@@ -12,10 +12,6 @@
 dl.tsd-comment-tags
     overflow: hidden
 
-    dt:before, dd:before
-        display: table
-        content: " "
-
     dt
         float: left
         padding: 1px 5px
@@ -28,6 +24,10 @@ dl.tsd-comment-tags
 
     dd
         margin: 0 0 10px 0
+
+		&:before, &:after
+			display: table
+			content: " "
         pre, &:after
             clear: both
 

--- a/src/default/assets/css/elements/_comment.sass
+++ b/src/default/assets/css/elements/_comment.sass
@@ -25,9 +25,9 @@ dl.tsd-comment-tags
     dd
         margin: 0 0 10px 0
 
-		&:before, &:after
-			display: table
-			content: " "
+        &:before, &:after
+            display: table
+            content: " "
         pre, &:after
             clear: both
 


### PR DESCRIPTION
Fixes #53, also https://github.com/TypeStrong/typedoc/issues/583

Before: 

![image](https://user-images.githubusercontent.com/121707/31674209-d9eee886-b326-11e7-9a4d-d765b39e7a4d.png)

After: 

![image](https://user-images.githubusercontent.com/121707/31676936-c22075be-b32e-11e7-912a-76afd9c7575d.png)
