### PR TITLE
Removed grunt-contrib-sass in favor of grunt-sass

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function(grunt)
 
 
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-sass');
+    grunt.loadNpmTasks('grunt-sass');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-string-replace');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-autoprefixer": "^3.0.4",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-sass": "^1.0.0",
+    "grunt-sass": "^2.1.0",
     "grunt-contrib-uglify": "^2.3.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-string-replace": "^1.0.0",


### PR DESCRIPTION
While running locally I encountered this [error](https://github.com/gruntjs/grunt-contrib-sass/issues/231), the issue is going on two years in Sept with no updates from the maintainers.

Compared to the actively developed `grunt-sass`, `grunt-contrib-sass` looks like abandonware.

No code changes was needed, just swapped the packages, tested results on my project and did not notice any issues.