### PR TITLE
Use HTML-escaping when displaying member names.

### DIFF
--- a/src/default/partials/member.declaration.hbs
+++ b/src/default/partials/member.declaration.hbs
@@ -1,5 +1,5 @@
 <div class="tsd-signature tsd-kind-icon">{{#compact}}
-    {{{wbr name}}}
+    {{name}}
     {{#if typeParameters}}
         &lt;
         {{#each typeParameters}}

--- a/src/default/partials/member.hbs
+++ b/src/default/partials/member.hbs
@@ -1,7 +1,7 @@
 <section class="tsd-panel tsd-member {{cssClasses}}">
     <a name="{{anchor}}" class="tsd-anchor"></a>
     {{#if name}}
-        <h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
+        <h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{name}}</h3>
     {{/if}}
 
     {{#if signatures}}


### PR DESCRIPTION
This fixes a bug where objects members with names that look like HTML
tags wouldn't properly be rendered.

The corresponding issue is
https://github.com/TypeStrong/typedoc/issues/780.

I expect tests in https://github.com/TypeStrong/typedoc to need to be updated. Let me know if the changes in this PR seem reasonable to you, if they are I'll open a separate PR in the typedoc repository in order to update the tests there.

If you would rather not change the template, what other approach should I use? I briefly considered HTML-escaping names in `src/lib/converter/nodes/variable.ts` but this didn't seem like a good idea to me.