### PR TITLE
Allow search results to be clicked before blur events happen

### DIFF
--- a/src/default/assets/js/main.js
+++ b/src/default/assets/js/main.js
@@ -394,6 +394,7 @@ var typedoc;
         var hasFocus = false;
         var preventPress = false;
         var index;
+        var resultClicked = false;
         function createIndex() {
             index = new lunr.Index();
             index.pipeline.add(lunr.trimmer);
@@ -499,10 +500,22 @@ var typedoc;
                 $field.blur();
             }
         }
+        $results
+            .on('mousedown', function () {
+            resultClicked = true;
+        })
+            .on('mouseup', function () {
+            resultClicked = false;
+            setHasFocus(false);
+        });
         $field.on('focusin', function () {
             setHasFocus(true);
             loadIndex();
         }).on('focusout', function () {
+            if (resultClicked) {
+                resultClicked = false;
+                return;
+            }
             setTimeout(function () { return setHasFocus(false); }, 100);
         }).on('input', function () {
             setQuery($.trim($field.val()));

--- a/src/default/assets/js/src/typedoc/components/Search.ts
+++ b/src/default/assets/js/src/typedoc/components/Search.ts
@@ -74,6 +74,12 @@ module typedoc.search
      */
     var index:lunr.Index;
 
+    /**
+     * Has a search result been clicked?
+     * Used to stop the results hiding before a user can fully click on a result.
+     */
+    var resultClicked:boolean = false;
+
 
     /**
      * Instantiate the lunr index.
@@ -223,6 +229,19 @@ module typedoc.search
         }
     }
 
+    /**
+     * Intercept mousedown and mouseup events so we can correctly
+     * handle clicking on search results
+     */
+    $results
+    .on('mousedown', () => {
+        resultClicked = true;
+    })
+    .on('mouseup', () => {
+        resultClicked = false;
+        setHasFocus(false);
+    });
+
 
     /**
      * Bind all required events on the input field.
@@ -231,6 +250,14 @@ module typedoc.search
         setHasFocus(true);
         loadIndex();
     }).on('focusout', () => {
+        // If the user just clicked on a search result, then
+        // don't lose the focus straight away, as this prevents
+        // them from clicking the result and following the link
+        if(resultClicked) {
+            resultClicked = false;
+            return;
+        }
+
         setTimeout(() => setHasFocus(false), 100);
     }).on('input', () => {
         setQuery($.trim($field.val()));


### PR DESCRIPTION
Fixes https://github.com/TypeStrong/typedoc-default-themes/issues/50 / https://github.com/TypeStrong/typedoc/issues/534

The mousedown event when a user clicks a search result happens before the search box focus is lost, so by setting a flag when this happens, we can stop the results from being hidden, meaning users can click on results properly.