### PR TITLE
Update links to use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Default themes for TypeDoc
 
 This module contains the default themes of TypeDoc.
-Visit http://typedoc.org/ to learn more about TypeDoc.
+Visit https://typedoc.org/ to learn more about TypeDoc.
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typedoc-default-themes",
   "description": "Default themes for TypeDoc.",
   "version": "0.5.0",
-  "homepage": "http://typedoc.org/",
+  "homepage": "https://typedoc.org/",
   "main": "bin/plugin.js",
   "files": [
     "bin",

--- a/src/default/partials/footer.hbs
+++ b/src/default/partials/footer.hbs
@@ -63,6 +63,6 @@
 
 {{#unless settings.hideGenerator}}
     <div class="container tsd-generator">
-        <p>Generated using <a href="http://typedoc.org/" target="_blank">TypeDoc</a></p>
+        <p>Generated using <a href="https://typedoc.org/" target="_blank">TypeDoc</a></p>
     </div>
 {{/unless}}


### PR DESCRIPTION
Hi, this would be part of the update for https://github.com/TypeStrong/typedoc/issues/955 , along with https://github.com/TypeStrong/typedoc/pull/982

If merged, it would break the tests on `typedoc` repo, so I think it could be either a minor or major version bump (`0.6.0` would not be picked). Cheers!