### PR TITLE
Support different hightlightjs themes

### DIFF
--- a/src/default/assets/css/highlightjs.sass
+++ b/src/default/assets/css/highlightjs.sass
@@ -1,0 +1,1 @@
+@import vendors/highlight.js

--- a/src/default/assets/css/main.sass
+++ b/src/default/assets/css/main.sass
@@ -1,7 +1,6 @@
 @import constants
 
 @import vendors/normalize
-@import vendors/highlight.js
 
 @import setup/mixins
 @import setup/grid

--- a/src/default/layouts/default.hbs
+++ b/src/default/layouts/default.hbs
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="{{relativeURL "assets/css/main.css"}}">
+    <link rel="stylesheet" href="{{relativeURL "assets/css/highlightjs.css"}}">
 </head>
 <body>
 


### PR DESCRIPTION
Hi,

This would be a part of fixing: https://github.com/TypeStrong/typedoc/issues/980 which is a nice feature that I am also interested in.

The other part, which would involve a PR in the typedoc repo, is already working here: https://github.com/TypeStrong/typedoc/compare/master...igncp:feature/support-highlight-themes

But waiting to create that PR in case you prefer another approach or wait for this. In addition to this PR, any further comments about the changes in the typedoc branch would be very appreciated.

Many thanks for maintaining the project 👍 