### PR TITLE
Upgrade jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,24 @@
       }
     },
     "@types/jquery": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.53.tgz",
-      "integrity": "sha512-MZKPWUhp5TKkoJ/58NSq6io+CSUCOHm2b3Z6U4+r9v70kktB0JM+eRjdp6YmDHtw0kK2XB7L2K7/FMIoziHjUA==",
-      "dev": true
+      "version": "3.3.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.29.tgz",
+      "integrity": "sha512-FhJvBninYD36v3k6c+bVk1DSZwh7B5Dpb/Pyk3HKVsiohn0nhbefZZ+3JXbWQhFyt0MxSl2jRDdGQPHeOHFXrQ==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
     },
     "@types/lunr": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.2.tgz",
       "integrity": "sha512-zcUZYquYDUEegRRPQtkZ068U9CoIjW6pJMYCVDRK25r76FEWvMm1oHqZQUfQh4ayIZ42lipXOpXEiAtGXc1XUg==",
+      "dev": true
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
     "@types/underscore": {
@@ -1255,8 +1264,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1277,14 +1285,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1299,20 +1305,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1429,8 +1432,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1442,7 +1444,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1457,7 +1458,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1465,14 +1465,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1491,7 +1489,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1572,8 +1569,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1585,7 +1581,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1671,8 +1666,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1708,7 +1702,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1728,7 +1721,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1772,14 +1764,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2771,9 +2761,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-base64": {
       "version": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "dependencies": {
     "backbone": "^1.1.2",
-    "jquery": "^2.2.4",
+    "jquery": "^3.3.1",
     "lunr": "^2.3.6",
     "underscore": "^1.9.1"
   },
   "devDependencies": {
     "@types/backbone": "^1.3.46",
-    "@types/jquery": "^2.0.53",
+    "@types/jquery": "^3.3.29",
     "@types/lunr": "^2.3.2",
     "@types/underscore": "^1.8.13",
     "grunt": "^1.0.1",

--- a/src/default/assets/js/src/typedoc/Application.ts
+++ b/src/default/assets/js/src/typedoc/Application.ts
@@ -96,7 +96,8 @@ namespace typedoc
      * Copy Backbone.Events to TypeScript class.
      */
     if (typeof Backbone != 'undefined') {
-        typedoc.Events = _.extend(function () {}, Backbone.Events);
+        typedoc.Events = function () {} as any;
+        _.extend(typedoc.Events.prototype, Backbone.Events);
     }
 
 

--- a/src/default/assets/js/src/typedoc/Application.ts
+++ b/src/default/assets/js/src/typedoc/Application.ts
@@ -96,11 +96,7 @@ namespace typedoc
      * Copy Backbone.Events to TypeScript class.
      */
     if (typeof Backbone != 'undefined') {
-        typedoc.Events = <any>(function() {
-            var res = function() {};
-            _.extend(res.prototype, Backbone.Events);
-            return res;
-        })();
+        typedoc.Events = _.extend(function () {}, Backbone.Events);
     }
 
 

--- a/src/default/assets/js/src/typedoc/components/Filter.ts
+++ b/src/default/assets/js/src/typedoc/components/Filter.ts
@@ -1,6 +1,6 @@
 namespace typedoc
 {
-    class FilterItem<T>
+    abstract class FilterItem<T>
     {
         protected key:string;
 
@@ -25,17 +25,11 @@ namespace typedoc
         protected initialize() {}
 
 
-        protected handleValueChange(oldValue:T, newValue:T) {}
+        protected abstract handleValueChange(oldValue:T, newValue:T): void;
 
+        protected abstract fromLocalStorage(value: string): T;
 
-        protected fromLocalStorage(value:string):T {
-            return <any>value;
-        }
-
-
-        protected toLocalStorage(value:T):string {
-            return <any>value;
-        }
+        protected abstract toLocalStorage(value: T): string;
 
 
         protected setValue(value:T) {
@@ -93,12 +87,12 @@ namespace typedoc
                 this.$select.addClass('active');
             }).on('mouseleave', () => {
                 this.$select.removeClass('active');
-            }).on(pointerUp, 'li', (e:JQueryMouseEventObject) => {
+            }).on(pointerUp, 'li', (e) => {
                 this.$select.removeClass('active');
-                this.setValue($(e.target).attr('data-value'));
+                this.setValue(($(e.target).attr('data-value') || '').toString());
             });
 
-            $document.on(pointerDown, (e:JQueryMouseEventObject) => {
+            $document.on(pointerDown, (e) => {
                 var $path = $(e.target).parents().addBack();
                 if ($path.is(this.$select)) return;
 
@@ -115,11 +109,19 @@ namespace typedoc
             $html.removeClass('toggle-' + oldValue);
             $html.addClass('toggle-' + newValue);
         }
+
+        protected fromLocalStorage(value: string): string {
+            return value;
+        }
+
+        protected toLocalStorage(value: string): string {
+            return value;
+        }
     }
 
 
     class Filter extends Backbone.View<any>
-    { 
+    {
         private optionVisibility:FilterItemSelect;
 
         private optionInherited:FilterItemCheckbox;

--- a/src/default/assets/js/src/typedoc/components/MenuHighlight.ts
+++ b/src/default/assets/js/src/typedoc/components/MenuHighlight.ts
@@ -8,17 +8,17 @@ namespace typedoc
         /**
          * jQuery instance of the anchor tag.
          */
-        $anchor?:JQuery;
+        $anchor?: JQuery;
 
         /**
          * jQuery instance of the link in the navigation representing this anchor.
          */
-        $link?:JQuery;
+        $link?: JQuery<Node>;
 
         /**
          * The vertical offset of the anchor on the page.
          */
-        position:number;
+        position: number;
     }
 
 

--- a/src/default/assets/js/src/typedoc/components/MenuSticky.ts
+++ b/src/default/assets/js/src/typedoc/components/MenuSticky.ts
@@ -111,14 +111,14 @@ namespace typedoc
             this.setState('');
 
             var containerTop    = this.$container.offset()!.top;
-            var containerHeight = this.$container.height();
+            var containerHeight = this.$container.height() || 0;
             var bottom          = containerTop + containerHeight;
-            if (this.$navigation.height() < containerHeight) {
-                var elHeight = this.$el.height();
+            if (this.$navigation.height()! < containerHeight) {
+                var elHeight = this.$el.height() || 0;
                 var elTop    = this.$el.offset()!.top;
 
                 if (this.$current.length) {
-                    var currentHeight = this.$current.height();
+                    var currentHeight = this.$current.height() || 0;
                     var currentTop    = this.$current.offset()!.top;
 
                     this.$navigation.css('top', containerTop - currentTop + 20);

--- a/src/default/assets/js/src/typedoc/components/Search.ts
+++ b/src/default/assets/js/src/typedoc/components/Search.ts
@@ -154,7 +154,7 @@ namespace typedoc.search
         }
 
         for (var i = 0, c = Math.min(10, res.length); i < c; i++) {
-            var row = data.rows[res[i].ref as any as number];
+            var row = data.rows[+res[i].ref];
 
             // Bold the matched part of the query in the search results
             var name = row.name.replace(new RegExp(query, 'i'), (match: string) => `<b>${match}</b>`);
@@ -273,7 +273,7 @@ namespace typedoc.search
 
         setTimeout(() => setHasFocus(false), 100);
     }).on('input', () => {
-        setQuery($.trim($field.val()));
+        setQuery($.trim(($field.val() || '').toString()));
     }).on('keydown', (e:JQueryKeyEventObject) => {
         if (e.keyCode == 13 || e.keyCode == 27 || e.keyCode == 38 || e.keyCode == 40) {
             preventPress = true;

--- a/src/default/assets/js/src/typedoc/components/Search.ts
+++ b/src/default/assets/js/src/typedoc/components/Search.ts
@@ -154,7 +154,7 @@ namespace typedoc.search
         }
 
         for (var i = 0, c = Math.min(10, res.length); i < c; i++) {
-            var row = data.rows[+res[i].ref];
+            var row = data.rows[Number(res[i].ref)];
 
             // Bold the matched part of the query in the search results
             var name = row.name.replace(new RegExp(query, 'i'), (match: string) => `<b>${match}</b>`);

--- a/src/default/assets/js/src/typedoc/components/Signature.ts
+++ b/src/default/assets/js/src/typedoc/components/Signature.ts
@@ -149,7 +149,7 @@ namespace typedoc
          *
          * @param e  The related jQuery event object.
          */
-        private onClick(e:JQueryMouseEventObject) {
+        private onClick(e: JQuery.ClickEvent | JQuery.TouchEventBase) {
             e.preventDefault();
             _(this.groups).forEach((group, index) => {
                 if (group.$signature.is(e.currentTarget)) {

--- a/src/default/assets/js/src/typedoc/components/Toggle.ts
+++ b/src/default/assets/js/src/typedoc/components/Toggle.ts
@@ -12,10 +12,10 @@ namespace typedoc
             super(options);
 
             this.className = this.$el.attr('data-toggle') || '';
-            this.$el.on(pointerUp, e => this.onPointerUp(e));
-            this.$el.on('click', e => e.preventDefault());
-            $document.on(pointerDown, e => this.onDocumentPointerDown(e));
-            $document.on(pointerUp, e => this.onDocumentPointerUp(e));
+            this.$el.on(pointerUp, (e) => this.onPointerUp(e));
+            this.$el.on('click', (e) => e.preventDefault());
+            $document.on(pointerDown, (e) => this.onDocumentPointerDown(e));
+            $document.on(pointerUp, (e) => this.onDocumentPointerUp(e));
         }
 
         setActive(value: boolean) {

--- a/src/default/assets/js/src/typedoc/components/Toggle.ts
+++ b/src/default/assets/js/src/typedoc/components/Toggle.ts
@@ -3,25 +3,22 @@ namespace typedoc
     /**
      * Enabled simple toggle buttons.
      */
-    class Toggle extends Backbone.View<any>
-    {
+    class Toggle extends Backbone.View<any> {
         active?: boolean;
 
         className!: string;
 
-
-        constructor(options:Backbone.ViewOptions<any>) {
+        constructor(options: Backbone.ViewOptions<any>) {
             super(options);
 
-            this.className = this.$el.attr('data-toggle');
-            this.$el.on(pointerUp, (e) => this.onPointerUp(e));
-            this.$el.on('click', (e) => e.preventDefault());
-            $document.on(pointerDown, (e) => this.onDocumentPointerDown(e));
-            $document.on(pointerUp, (e) => this.onDocumentPointerUp(e));
+            this.className = this.$el.attr('data-toggle') || '';
+            this.$el.on(pointerUp, e => this.onPointerUp(e));
+            this.$el.on('click', e => e.preventDefault());
+            $document.on(pointerDown, e => this.onDocumentPointerDown(e));
+            $document.on(pointerUp, e => this.onDocumentPointerUp(e));
         }
 
-
-        setActive(value:boolean) {
+        setActive(value: boolean) {
             if (this.active == value) return;
             this.active = value;
 
@@ -33,17 +30,17 @@ namespace typedoc
             setTimeout(() => $html.removeClass(transition), 500);
         }
 
-
-        onPointerUp(event:JQueryMouseEventObject) {
+        onPointerUp(event: JQuery.TriggeredEvent) {
             if (hasPointerMoved) return;
             this.setActive(true);
             event.preventDefault();
         }
 
-
-        onDocumentPointerDown(e:JQueryMouseEventObject) {
+        onDocumentPointerDown(e: JQuery.TriggeredEvent) {
             if (this.active) {
-                var $path = $(e.target).parents().addBack();
+                var $path = $(e.target)
+                    .parents()
+                    .addBack();
                 if ($path.hasClass('col-menu')) {
                     return;
                 }
@@ -56,10 +53,12 @@ namespace typedoc
             }
         }
 
-        onDocumentPointerUp(e:JQueryMouseEventObject) {
+        onDocumentPointerUp(e: JQuery.TriggeredEvent) {
             if (hasPointerMoved) return;
             if (this.active) {
-                var $path = $(e.target).parents().addBack();
+                var $path = $(e.target)
+                    .parents()
+                    .addBack();
                 if ($path.hasClass('col-menu')) {
                     var $link = $path.filter('a');
                     if ($link.length) {

--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -26,8 +26,8 @@ namespace typedoc
          */
         constructor() {
             super();
-            $window.on('scroll', <any>_(() => this.onScroll()).throttle(10));
-            $window.on('resize', <any>_(() => this.onResize()).throttle(10));
+            $window.on('scroll', _.throttle(() => this.onScroll(), 10))
+            $window.on('resize', _.throttle(() => this.onResize(), 10));
 
             this.onResize();
             this.onScroll();
@@ -46,8 +46,8 @@ namespace typedoc
          * Triggered when the size of the window has changed.
          */
         onResize() {
-            this.width  = $window.width();
-            this.height = $window.height();
+            this.width = $window.width() || 0;
+            this.height = $window.height() || 0;
             this.trigger('resize', this.width, this.height);
         }
 
@@ -56,7 +56,7 @@ namespace typedoc
          * Triggered when the user scrolled the viewport.
          */
         onScroll() {
-            this.scrollTop = $window.scrollTop();
+            this.scrollTop = $window.scrollTop() || 0;
             this.trigger('scroll', this.scrollTop);
         }
     }

--- a/src/default/assets/js/src/typedoc/utils/pointer.ts
+++ b/src/default/assets/js/src/typedoc/utils/pointer.ts
@@ -62,23 +62,23 @@ namespace typedoc
         pointerUp   = 'touchend';
     }
 
-    $document.on(pointerDown, (e:JQueryMouseEventObject) => {
+    $document.on(pointerDown, (e) => {
         isPointerDown = true;
         hasPointerMoved = false;
         var t = (pointerDown == 'touchstart' ? (e.originalEvent as TouchEvent).targetTouches[0] : e);
-        pointerDownPosition.x = t.pageX;
-        pointerDownPosition.y = t.pageY;
-    }).on(pointerMove, (e:JQueryMouseEventObject) => {
+        pointerDownPosition.y = t.pageY || 0;
+        pointerDownPosition.x = t.pageX || 0;
+    }).on(pointerMove, (e) => {
         if (!isPointerDown) return;
         if (!hasPointerMoved) {
             var t = (pointerDown == 'touchstart' ? (e.originalEvent as TouchEvent).targetTouches[0] : e);
-            var x = pointerDownPosition.x - t.pageX;
-            var y = pointerDownPosition.y - t.pageY;
+            var x = pointerDownPosition.x - (t.pageX || 0);
+            var y = pointerDownPosition.y - (t.pageY || 0);
             hasPointerMoved = (Math.sqrt(x*x + y*y) > 10);
         }
-    }).on(pointerUp, (e:JQueryMouseEventObject) => {
+    }).on(pointerUp, (e) => {
         isPointerDown = false;
-    }).on('click', (e:JQueryMouseEventObject) => {
+    }).on('click', (e) => {
         if (preventNextClick) {
             e.preventDefault();
             e.stopImmediatePropagation();

--- a/src/default/assets/js/src/typedoc/utils/transitions.ts
+++ b/src/default/assets/js/src/typedoc/utils/transitions.ts
@@ -29,13 +29,13 @@ namespace typedoc {
 
 
     export function animateHeight($el: JQuery, callback:Function, success?:Function) {
-        let from = $el.height()
+        let from = $el.height() || 0;
         let to = from;
         noTransition($el, function () {
             callback();
 
             $el.css('height', '');
-            to = $el.height();
+            to = $el.height() || 0;
             if (from != to && transition) $el.css('height', from);
         });
 


### PR DESCRIPTION
closes https://github.com/TypeStrong/typedoc/issues/994

Upgrades jQuery to the latest version and resolves type incompatibilities. Most were caused by methods which can apparently return undefined (`.height()`, really?) so I just added `|| 0` to those statements. 

I also removed a few casts to `any`.

I don't generally use jQuery, so it's certainly possible I missed a better way to handle this.