### PR TITLE
Fixed typo in class name

### DIFF
--- a/src/default/partials/parameter.hbs
+++ b/src/default/partials/parameter.hbs
@@ -1,6 +1,6 @@
 <ul class="tsd-parameters">
     {{#if signatures}}
-        <li class="tsd-parameter-siganture">
+        <li class="tsd-parameter-signature">
             <ul class="tsd-signatures {{cssClasses}}">
                 {{#each signatures}}
                     <li class="tsd-signature tsd-kind-icon">{{> member.signature.title hideName=true }}</li>


### PR DESCRIPTION
Not sure of the impact of this change? Do people already rely on that? Merging as-is is good?