### PR TITLE
Add hideShowToolbar() to onScroll()

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
   },
   "devDependencies": {
     "@types/backbone": "^1.4.1",
-    "@types/jquery": "^3.3.30",
     "@types/lunr": "^2.3.2",
-    "@types/underscore": "^1.9.2",
     "grunt": "^1.0.4",
     "grunt-autoprefixer": "^3.0.4",
     "grunt-cli": "^1.2.0",

--- a/src/default/assets/css/elements/_navigation.sass
+++ b/src/default/assets/css/elements/_navigation.sass
@@ -115,6 +115,11 @@
     position: -webkit-sticky
     position: sticky
     top: .5rem
+    transition: .3s
+
+    &.tsd-navigation--displace
+        max-height: calc(100vh - 1rem - #{$TOOLBAR_HEIGHT})
+        top: calc(.5rem + #{$TOOLBAR_HEIGHT});
 
     ul
         +INDENTS(6, 25, 20)

--- a/src/default/assets/css/elements/_navigation.sass
+++ b/src/default/assets/css/elements/_navigation.sass
@@ -119,7 +119,7 @@
 
     &.tsd-navigation--displace
         max-height: calc(100vh - 1rem - #{$TOOLBAR_HEIGHT})
-        top: calc(.5rem + #{$TOOLBAR_HEIGHT});
+        top: calc(.5rem + #{$TOOLBAR_HEIGHT})
 
     ul
         +INDENTS(6, 25, 20)

--- a/src/default/assets/css/elements/_navigation.sass
+++ b/src/default/assets/css/elements/_navigation.sass
@@ -110,16 +110,16 @@
 // </nav>
 //
 .tsd-navigation.secondary
-    max-height: calc(100vh - 1rem)
+    max-height: calc(100vh - 1rem - #{$TOOLBAR_HEIGHT})
     overflow: auto
     position: -webkit-sticky
     position: sticky
-    top: .5rem
+    top: calc(.5rem + #{$TOOLBAR_HEIGHT})
     transition: .3s
 
-    &.tsd-navigation--displace
-        max-height: calc(100vh - 1rem - #{$TOOLBAR_HEIGHT})
-        top: calc(.5rem + #{$TOOLBAR_HEIGHT});
+    &.tsd-navigation--toolbar-hide
+        max-height: calc(100vh - 1rem)
+        top: .5rem
 
     ul
         +INDENTS(6, 25, 20)

--- a/src/default/assets/css/elements/_toolbar.sass
+++ b/src/default/assets/css/elements/_toolbar.sass
@@ -11,7 +11,7 @@
 // </div>
 //
 .tsd-page-toolbar
-    position: absolute
+    position: fixed
     z-index: 1
     top: 0
     left: 0
@@ -20,6 +20,7 @@
     color: $TOOLBAR_TEXT_COLOR
     background: $TOOLBAR_COLOR
     border-bottom: 1px solid $COLOR_PANEL_DIVIDER
+    transition: transform .3s linear
 
     a
         color: $TOOLBAR_TEXT_COLOR
@@ -44,6 +45,9 @@
 
         &:first-child
             width: 100%
+
+.tsd-page-toolbar--hide
+    transform: translateY(-100%)
 
 %TSD_WIDGET_ICON
     &:before

--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -38,6 +38,11 @@ namespace typedoc
          */
         showToolbar:boolean = true;
 
+        /**
+         * The toolbar (contains the search input).
+         */
+        secondaryNav:HTMLElement;
+
 
         /**
          * Create new Viewport instance.
@@ -46,6 +51,7 @@ namespace typedoc
             super();
 
             this.toolbar = <HTMLDivElement>document.querySelector('.tsd-page-toolbar');
+            this.secondaryNav = <HTMLElement>document.querySelector('.tsd-navigation.secondary');
 
             $window.on('scroll', _.throttle(() => this.onScroll(), 10))
             $window.on('resize', _.throttle(() => this.onResize(), 10));
@@ -91,6 +97,7 @@ namespace typedoc
             this.showToolbar = this.lastY >= this.scrollTop || this.scrollTop === 0;
             if (isShown !== this.showToolbar) {
                 this.toolbar.classList[this.showToolbar ? 'remove' : 'add']('tsd-page-toolbar--hide');
+                this.secondaryNav.classList[this.showToolbar ? 'add' : 'remove']('tsd-navigation--displace');
             }
             this.lastY = this.scrollTop;
         }

--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -39,7 +39,7 @@ namespace typedoc
         showToolbar:boolean = true;
 
         /**
-         * The toolbar (contains the search input).
+         * The sticky side nav that contains members of the current page.
          */
         secondaryNav:HTMLElement;
 
@@ -96,8 +96,8 @@ namespace typedoc
             const isShown = this.showToolbar;
             this.showToolbar = this.lastY >= this.scrollTop || this.scrollTop === 0;
             if (isShown !== this.showToolbar) {
-                this.toolbar.classList[this.showToolbar ? 'remove' : 'add']('tsd-page-toolbar--hide');
-                this.secondaryNav.classList[this.showToolbar ? 'add' : 'remove']('tsd-navigation--displace');
+                this.toolbar.classList.toggle('tsd-page-toolbar--hide');
+                this.secondaryNav.classList.toggle('tsd-navigation--toolbar-hide');
             }
             this.lastY = this.scrollTop;
         }

--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -14,6 +14,11 @@ namespace typedoc
         scrollTop:number = 0;
 
         /**
+         * The previous scrollTop.
+         */
+        lastY:number = 0;
+
+        /**
          * The width of the window.
          */
         width:number = 0;
@@ -23,12 +28,25 @@ namespace typedoc
          */
         height:number = 0;
 
+        /**
+         * The toolbar (contains the search input).
+         */
+        toolbar:HTMLDivElement;
+
+        /**
+         * Boolean indicating whether the toolbar is shown.
+         */
+        showToolbar:boolean = true;
+
 
         /**
          * Create new Viewport instance.
          */
         constructor() {
             super();
+
+            this.toolbar = <HTMLDivElement>document.querySelector('.tsd-page-toolbar');
+
             $window.on('scroll', _.throttle(() => this.onScroll(), 10))
             $window.on('resize', _.throttle(() => this.onResize(), 10));
 
@@ -61,6 +79,20 @@ namespace typedoc
         onScroll() {
             this.scrollTop = $window.scrollTop() || 0;
             this.trigger('scroll', this.scrollTop);
+            this.hideShowToolbar();
+        }
+
+
+        /**
+         * Handle hiding/showing of the toolbar.
+         */
+        hideShowToolbar() {
+            const isShown = this.showToolbar;
+            this.showToolbar = this.lastY >= this.scrollTop || this.scrollTop === 0;
+            if (isShown !== this.showToolbar) {
+                this.toolbar.classList[this.showToolbar ? 'remove' : 'add']('tsd-page-toolbar--hide');
+            }
+            this.lastY = this.scrollTop;
         }
     }
 

--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -39,7 +39,7 @@ namespace typedoc
         showToolbar:boolean = true;
 
         /**
-         * The toolbar (contains the search input).
+         * The sticky side nav that contains members of the current page.
          */
         secondaryNav:HTMLElement;
 


### PR DESCRIPTION
Toolbar will hide and show as you scroll up and down. One quibble is that it obscures a bit of text on the side navigation menu.

Edit: I fixed the obscuring. The secondary nav now resizes when needed on scroll.

Edit 2: I noticed that the search results don't go away if you scroll. I think maybe the toolbar should remain visible if there are search results. I'll look into it.