### PR TITLE
Removed non-standard CSS properties

### DIFF
--- a/src/default/assets/css/elements/_index.sass
+++ b/src/default/assets/css/elements/_index.sass
@@ -47,7 +47,6 @@
             +vendors(column-count, 2)
 
         li
-            +vendors(column-break-inside, avoid)
             +vendors(page-break-inside, avoid)
 
     a,

--- a/src/default/assets/css/layouts/_default.sass
+++ b/src/default/assets/css/layouts/_default.sass
@@ -18,7 +18,6 @@ html.default
             position: fixed !important
             overflow: auto
             -webkit-overflow-scrolling: touch
-            overflow-scrolling: touch
             z-index: 1024
             top: 0 !important
             bottom: 0 !important

--- a/src/default/assets/css/layouts/_minimal.sass
+++ b/src/default/assets/css/layouts/_minimal.sass
@@ -13,7 +13,6 @@ html.minimal
         position: fixed !important
         overflow: auto
         -webkit-overflow-scrolling: touch
-        overflow-scrolling: touch
         box-sizing: border-box
         z-index: 1
         left: 0

--- a/src/default/assets/css/setup/_mixins.sass
+++ b/src/default/assets/css/setup/_mixins.sass
@@ -14,7 +14,7 @@
         height: 0
 
 @mixin retina
-    @media (-webkit-min-device-pixel-ratio: 1.5), (min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)
+    @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)
         &
             @content
 


### PR DESCRIPTION
The following CSS properties are non-standard and are reported as bugs by SonarQube:

* min-device-pixel-ratio
* overflow-scrolling
* column-break-inside

Therefore I removed them from the SASS files.