### PR TITLE
Render hyperlink for TypeOperatorType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-default-themes",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-default-themes",
   "description": "Default themes for TypeDoc.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "homepage": "https://typedoc.org/",
   "main": "bin/plugin.js",
   "files": [

--- a/src/default/partials/type.hbs
+++ b/src/default/partials/type.hbs
@@ -64,28 +64,34 @@
                             {{/if}}
                         {{/compact}}
                     {{else}}
-                        {{#compact}}
-                            <span class="tsd-signature-type">
-                                {{#if name}}
-                                    {{name}}
-                                {{else if value}}
-                                    "{{value}}"
-                                {{else}}
-                                    {{this}}
+                        {{#if operator}}
+                            {{#compact}}
+                                <span class="tsd-signature-type">{{operator}}&nbsp;{{#with target}}{{>type}}{{/with}}</span>
+                            {{/compact}}
+                        {{else}}
+                            {{#compact}}
+                                <span class="tsd-signature-type">
+                                    {{#if name}}
+                                        {{name}}
+                                    {{else if value}}
+                                        "{{value}}"
+                                    {{else}}
+                                        {{this}}
+                                    {{/if}}
+                                </span>
+                                {{#if typeArguments}}
+                                    <span class="tsd-signature-symbol">&lt;</span>
+
+                                    {{#each typeArguments}}
+                                        {{#if @index}}
+                                            <span class="tsd-signature-symbol">, </span>
+                                        {{/if}}{{> type}}
+                                    {{/each}}
+
+                                    <span class="tsd-signature-symbol">&gt;</span>
                                 {{/if}}
-                            </span>
-                            {{#if typeArguments}}
-                                <span class="tsd-signature-symbol">&lt;</span>
-
-                                {{#each typeArguments}}
-                                    {{#if @index}}
-                                        <span class="tsd-signature-symbol">, </span>
-                                    {{/if}}{{> type}}
-                                {{/each}}
-
-                                <span class="tsd-signature-symbol">&gt;</span>
-                            {{/if}}
-                        {{/compact}}
+                            {{/compact}}
+                        {{/if}}
                     {{/ifCond}}
                 {{/if}}
             {{/if}}


### PR DESCRIPTION
Add support for hyperlinking of `TypeOperatorType` types.

Related to the following [comment](https://github.com/TypeStrong/typedoc/issues/1148#issuecomment-568608150):

> Not linking to callbacks in `keyof Callbacks` sounds like a bug to me.

https://github.com/TypeStrong/typedoc/pull/1161 accompanies this change.
