### PR TITLE
Improve box-shadow and border-radius for .tsd-panel and .tsd-page-title

### DIFF
--- a/src/default/assets/css/elements/_panel.sass
+++ b/src/default/assets/css/elements/_panel.sass
@@ -11,7 +11,8 @@
     margin: 20px 0
     padding: 20px
     background-color: $COLOR_PANEL
-    box-shadow: 0 0 4px rgba(#000, 0.25)
+    border-radius: 8px
+    box-shadow: 0 2px 4px rgba(#000, 0.15)
 
     &:empty
         display: none

--- a/src/default/assets/css/layouts/_default.sass
+++ b/src/default/assets/css/layouts/_default.sass
@@ -89,7 +89,7 @@ html.default
     padding: 70px 0 20px 0
     margin: 0 0 40px 0
     background: $COLOR_PANEL
-    box-shadow: 0 0 5px rgba(#000, 0.35)
+    box-shadow: 0 2px 4px rgba(#000, 0.15)
 
     h1
         margin: 0


### PR DESCRIPTION
Hi, I've made some improvements for `.tsd-panel` and `.tsd-page-title` classes.

This is the result: 
![Screenshot_2020-01-12 Mongol albert-team mongol - v0 1 3(1)](https://user-images.githubusercontent.com/20436482/72222019-b405d580-3592-11ea-883b-bc34a24d64a9.png)
