### PR TITLE
Fix text overflow issue when variables are long

### DIFF
--- a/src/default/assets/css/elements/_signatures.sass
+++ b/src/default/assets/css/elements/_signatures.sass
@@ -17,6 +17,7 @@
     border: 1px solid $COLOR_PANEL_DIVIDER
     font-family: $FONT_FAMILY_MONO
     font-size: $FONT_SIZE_MONO
+    overflow-x: scroll
 
     &.tsd-kind-icon
         padding-left: 30px

--- a/src/default/assets/css/elements/_signatures.sass
+++ b/src/default/assets/css/elements/_signatures.sass
@@ -17,7 +17,7 @@
     border: 1px solid $COLOR_PANEL_DIVIDER
     font-family: $FONT_FAMILY_MONO
     font-size: $FONT_SIZE_MONO
-    overflow-x: scroll
+    overflow-x: auto
 
     &.tsd-kind-icon
         padding-left: 30px


### PR DESCRIPTION
When typedoc renders variables in the project which are too long, we see text overflow(Please see the image below). I just made a quick fix.

![Screenshot 2020-01-31 at 12 27 42 PM](https://user-images.githubusercontent.com/6939097/73536646-a079bc00-4426-11ea-8ac2-a3e517054b34.png)