### PR TITLE
fix: guard against null checkbox in handleValueChange

### DIFF
--- a/src/default/assets/js/src/typedoc/components/Filter.ts
+++ b/src/default/assets/js/src/typedoc/components/Filter.ts
@@ -65,6 +65,7 @@ namespace typedoc
 
 
         protected handleValueChange(oldValue:boolean, newValue:boolean) {
+            if (!this.checkbox) return;
             this.checkbox.checked = this.value;
             document.documentElement.classList.toggle('toggle-' + this.key, this.value != this.defaultValue);
         }


### PR DESCRIPTION
When a `FilterItemCheckbox` (e.g., "Only Exported") is not rendered (because `--excludeNotExported true` was used) but there is a previously saved `localStorage` value for the setting, the `initialize()` code throws an error and `main.js` fails to initialize causing all javascript features to stop working.

This happens because:

- `FilterItemCheckbox` extends `FilterItem`
- The `FilterItem` constructor calls `FilterItemCheckbox.initialize()`:

```js
            const checkbox = document.querySelector<HTMLInputElement>('#tsd-filter-' + this.key);
            if (!checkbox) return;   // this.checkbox can be undefined

            this.checkbox = checkbox;
            this.checkbox.addEventListener('change', () => {
                this.setValue(this.checkbox.checked);
            });
```

- The `FilterItem` constructor then calls `setValue` :

```js
            if (window.localStorage[this.key]) {
                this.setValue(this.fromLocalStorage(window.localStorage[this.key]));
            }
```

- `SetValue` delegates to `handleValueChange`:

```
        protected handleValueChange(oldValue:boolean, newValue:boolean) {
            this.checkbox.checked = this.value; // this.checkbox is undefined
```
