### PR TITLE
Output type parameter default values

### DIFF
--- a/src/default/partials/typeParameters.hbs
+++ b/src/default/partials/typeParameters.hbs
@@ -7,6 +7,9 @@
                     <span class="tsd-signature-symbol">:&nbsp;</span>
                     {{#with type}}{{> type}}{{/with}}
                 {{/if}}
+                {{#if default}}
+                    &nbsp;=&nbsp;{{#with default}}{{> type}}{{/with}}
+                {{/if}}
             {{/compact}}</h4>
             {{> comment}}
         </li>


### PR DESCRIPTION
Since this [PR](https://github.com/TypeStrong/typedoc/pull/1348) was merged typedoc supports default values for type parameters. So why not show them in the docs?

The format is simply:

    * A = TheType

with `A` being the type parameter and `TheType` the default type for that parameter and it looks like this:

![Screenshot](https://images2.imgbox.com/7d/aa/FFOgjiGH_o.png)

I'm open for better ideas though.