### PR TITLE
Use lump categories in index if they exist, README date

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ in the project where you want to use your local build run `npm install ../path/t
 ## License
 
 Copyright (c) 2015 [Sebastian Lenz](http://www.sebastian-lenz.de).<br>
-Copyright (c) 2016-2019 [TypeDoc Contributors](https://github.com/TypeStrong/typedoc/graphs/contributors).<br>
+Copyright (c) 2016-2020 [TypeDoc Contributors](https://github.com/TypeStrong/typedoc/graphs/contributors).<br>
 Licensed under the Apache License 2.0.

--- a/src/default/partials/index.hbs
+++ b/src/default/partials/index.hbs
@@ -1,30 +1,50 @@
-{{#if groups}}
-<section class="tsd-panel-group tsd-index-group">
-    <h2>Index</h2>
-    <section class="tsd-panel tsd-index-panel">
-        <div class="tsd-index-content">
-            {{#each groups}}
-                <section class="tsd-index-section {{cssClasses}}">
-                    {{#if categories}}
-                        {{#each categories}}
-                            <h3>{{#if title}}{{title}} {{/if}}{{../title}}</h3>
-                            <ul class="tsd-index-list">
-                                {{#each children}}
-                                    <li class="{{cssClasses}}"><a href="{{relativeURL url}}" class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a></li>
-                                {{/each}}
-                            </ul>
-                        {{/each}}
-                    {{else}}
+{{#if categories}}
+    <section class="tsd-panel-group tsd-index-group">
+        <h2>Index</h2>
+        <section class="tsd-panel tsd-index-panel">
+            <div class="tsd-index-content">
+                {{#each categories}}
+                    <section class="tsd-index-section">
                         <h3>{{title}}</h3>
                         <ul class="tsd-index-list">
                             {{#each children}}
                                 <li class="{{cssClasses}}"><a href="{{relativeURL url}}" class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a></li>
                             {{/each}}
                         </ul>
-                    {{/if}}
-                </section>
-            {{/each}}
-        </div>
+                    </section>
+                {{/each}}
+            </div>
+        </section>
     </section>
-</section>
+{{else}}
+    {{#if groups}}
+    <section class="tsd-panel-group tsd-index-group">
+        <h2>Index</h2>
+        <section class="tsd-panel tsd-index-panel">
+            <div class="tsd-index-content">
+                {{#each groups}}
+                    <section class="tsd-index-section {{cssClasses}}">
+                        {{#if categories}}
+                            {{#each categories}}
+                                <h3>{{#if title}}{{title}} {{/if}}{{../title}}</h3>
+                                <ul class="tsd-index-list">
+                                    {{#each children}}
+                                        <li class="{{cssClasses}}"><a href="{{relativeURL url}}" class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a></li>
+                                    {{/each}}
+                                </ul>
+                            {{/each}}
+                        {{else}}
+                            <h3>{{title}}</h3>
+                            <ul class="tsd-index-list">
+                                {{#each children}}
+                                    <li class="{{cssClasses}}"><a href="{{relativeURL url}}" class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a></li>
+                                {{/each}}
+                            </ul>
+                        {{/if}}
+                    </section>
+                {{/each}}
+            </div>
+        </section>
+    </section>
+    {{/if}}
 {{/if}}


### PR DESCRIPTION
This PR addresses https://github.com/TypeStrong/typedoc/issues/1199, which appears to just be a theme issue. When `categorizeByGroup` is false, this PR causes the theme to use the produced lump categories within the index. It was already using them in the members section. I don't know if this affects any tests in the Typedoc repo.

There's also a minor change to update 2019 -> 2020 in the readme.

Old:
![image](https://user-images.githubusercontent.com/1202288/92946999-6b563300-f425-11ea-970a-84a4d3cd3e6b.png)


New:
![image](https://user-images.githubusercontent.com/1202288/92946933-524d8200-f425-11ea-9be0-e338802c33e3.png)
