### PR TITLE
Allow setting a base url

### DIFF
--- a/src/default/layouts/default.hbs
+++ b/src/default/layouts/default.hbs
@@ -2,6 +2,7 @@
 <html class="default no-js">
 <head>
     <meta charset="utf-8">
+    {{#if model.base}}<base href="{{model.base}}">{{/if}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{{#ifCond model.name '==' project.name}}{{project.name}}{{else}}{{model.name}} | {{project.name}}{{/ifCond}}</title>
     <meta name="description" content="Documentation for {{project.name}}">


### PR DESCRIPTION
Use case or this: github pages where you cannot use the documentation as all the links are dead.

Should you like it, I can open a PR for the documentaion too