### PR TITLE
style: add border-left for default blockquote style

### DIFF
--- a/src/default/assets/css/setup/_typography.sass
+++ b/src/default/assets/css/setup/_typography.sass
@@ -26,6 +26,11 @@ pre
         font-size: 100%
         background-color: transparent
 
+blockquote
+    margin: 1em 0
+    padding-left: 1em
+    border-left: 4px solid gray
+
 .tsd-typography
     line-height: $LINE_HEIGHT
 


### PR DESCRIPTION
Default blockquote doesn't have style like github markdown.
![image](https://user-images.githubusercontent.com/25154432/106347042-67ed1680-62f6-11eb-8504-5a2bc58841ee.png)
After this:
![image](https://user-images.githubusercontent.com/25154432/106347115-eea1f380-62f6-11eb-8d9d-feb8de29530f.png)
