### PR TITLE
Show the toolbar if we are at or above the top

### DIFF
--- a/src/default/assets/js/src/typedoc/services/Viewport.ts
+++ b/src/default/assets/js/src/typedoc/services/Viewport.ts
@@ -120,7 +120,7 @@ export class Viewport extends EventTarget {
      */
     hideShowToolbar() {
         const isShown = this.showToolbar;
-        this.showToolbar = this.lastY >= this.scrollTop || this.scrollTop === 0;
+        this.showToolbar = this.lastY >= this.scrollTop || this.scrollTop <= 0;
         if (isShown !== this.showToolbar) {
             this.toolbar.classList.toggle("tsd-page-toolbar--hide");
             this.secondaryNav.classList.toggle("tsd-navigation--toolbar-hide");


### PR DESCRIPTION
Safari on macOS and iOS adds a 'spring' effect when trying to scroll up at the top of the page. The second half of the spring, when it bounces back down to the top of the page, causes the toolbar to hide then show again. This is incredibly distracting and counterintuitive. This fix makes the toolbar visible if the scroll is anywhere at or above the top of the page.