### PR TITLE
Fix invalid use of `rgba()` for code background

### DIFF
--- a/src/default/assets/css/_theme.scss
+++ b/src/default/assets/css/_theme.scss
@@ -15,7 +15,7 @@
     --color-comment-tag: #707070;
     --color-comment-tag-text: #fff;
 
-    --color-code-background: rgba(#000, 0.04);
+    --color-code-background: rgba(0, 0, 0, 0.04);
 
     --color-ts: #9600ff;
     --color-ts-interface: #647f1b;


### PR DESCRIPTION
Browsers were rendering all code blocks with a white background, as `rgba()` does not accept a hex color.